### PR TITLE
Fix issues #06 and #08: Move prompt below conversation and rename clear button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -104,6 +104,40 @@
 </table>
 <br>
 
+<!-- CONVERSATION PANEL -->
+<table border="0" cellspacing="0" cellpadding="0" width="100%">
+<tr><td>
+<font face="Charcoal, Geneva, Chicago, Arial, sans-serif" size="2"><b>Conversation :</b></font>
+</td></tr>
+</table>
+<br>
+<table border="0" cellspacing="0" cellpadding="0" width="100%">
+<tr><td bgcolor="#666666">
+<table border="0" cellspacing="1" cellpadding="0" width="100%">
+<tr><td bgcolor="#111133">
+<table border="0" cellspacing="0" cellpadding="4" width="100%">
+{% if history %}
+  {% for msg in history %}
+  <tr><td>
+    <font face="Monaco, Courier, monospace" size="2" color="{% if msg.role == 'user' %}#55EE55{% else %}#55FFFF{% endif %}">
+      {% if msg.role == 'user' %}Vous :{% else %}Bot :{% endif %} {{ msg.content|nl2br }}
+    </font>
+  </td></tr>
+  {% endfor %}
+{% else %}
+  <tr><td>
+    <font face="Monaco, Courier, monospace" size="2" color="#55EE55">
+      Aucun message pour l'instant.
+    </font>
+  </td></tr>
+{% endif %}
+</table>
+</td></tr>
+</table>
+</td></tr>
+</table>
+
+<br>
 <!-- PROMPT LABEL -->
 <font face="Charcoal, Geneva, Chicago, Arial, sans-serif" size="2"><b>Prompt :</b></font>
 <br>
@@ -150,7 +184,7 @@
     <tr><td bgcolor="#FFFFFF">
     <table border="0" cellspacing="1" cellpadding="0">
     <tr><td bgcolor="#999999">
-    <form method="GET" action="/"><input type="submit" value=" Effacer "></form>
+    <form method="GET" action="/clear"><input type="submit" value=" Nouvelle conversation "></form>
     </td></tr>
     </table>
     </td></tr>
@@ -179,41 +213,6 @@
     </table>
   </td>
 </tr>
-</table>
-
-<br>
-
-<!-- CONVERSATION PANEL -->
-<table border="0" cellspacing="0" cellpadding="0" width="100%">
-<tr><td>
-<font face="Charcoal, Geneva, Chicago, Arial, sans-serif" size="2"><b>Conversation :</b></font>
-</td></tr>
-</table>
-<br>
-<table border="0" cellspacing="0" cellpadding="0" width="100%">
-<tr><td bgcolor="#666666">
-<table border="0" cellspacing="1" cellpadding="0" width="100%">
-<tr><td bgcolor="#111133">
-<table border="0" cellspacing="0" cellpadding="4" width="100%">
-{% if history %}
-  {% for msg in history %}
-  <tr><td>
-    <font face="Monaco, Courier, monospace" size="2" color="{% if msg.role == 'user' %}#55EE55{% else %}#55FFFF{% endif %}">
-      {% if msg.role == 'user' %}Vous :{% else %}Bot :{% endif %} {{ msg.content|nl2br }}
-    </font>
-  </td></tr>
-  {% endfor %}
-{% else %}
-  <tr><td>
-    <font face="Monaco, Courier, monospace" size="2" color="#55EE55">
-      Aucun message pour l'instant.
-    </font>
-  </td></tr>
-{% endif %}
-</table>
-</td></tr>
-</table>
-</td></tr>
 </table>
 
 <br>


### PR DESCRIPTION
## Summary

- **Issue #06**: Déplacement du champ de prompt et du bouton Envoyer sous la zone de conversation
- **Issue #08**: Renommage du bouton "Effacer" en "Nouvelle conversation" et correction du lien vers /clear

## Changes

### Issue #06
- Déplacé le champ de prompt (textarea) et le bouton "Envoyer" sous la zone de conversation
- La nouvelle structure HTML est maintenant : messages d'erreur → sélecteur de modèle → conversation → prompt → boutons d'action → pied de page
- Le sélecteur de modèle reste en haut (avant la conversation)
- Les boutons d'action restent à leur position (après le prompt)

### Issue #08
- Renommé le bouton "Effacer" en "Nouvelle conversation"
- Changé l'action du bouton de `/` vers `/clear` (qui existe déjà dans app.py)
- La route `/clear` vide `_conversation_history` et réinitialise les champs correctement

## Verification
- HTML4 strict compatible (pas de JavaScript)
- Encodage ISO-8859-1 respecté
- Style visuel Mac OS 8.6 Platinum conservé
- Flask app structure verified